### PR TITLE
Prevent single whitespace at the end of lines

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -18,6 +18,6 @@ class PrettyjsonCommand(sublime_plugin.TextCommand):
 
             try:
                 obj = json.loads(self.view.substr(selection))
-                self.view.replace(edit, selection, json.dumps(obj, indent=s.get("indent_size", 4), ensure_ascii=False, sort_keys=s.get("sort_keys", True)))
+                self.view.replace(edit, selection, json.dumps(obj, indent=s.get("indent_size", 4), ensure_ascii=False, sort_keys=s.get("sort_keys", True), separators=(',', ': ')))
             except Exception, e:
                 sublime.status_message(str(e))


### PR DESCRIPTION
Configure json.dumps() to use an item separator of "," instead of the default ", " to prevent single whitespace at the end of lines.

Without this option, all prettyfied JSON has one space at the end of each line, which is not so pretty:

{
  "key": "value",_
  "key": "value",_
  "key": "value"
}

This could of course be configured, but with the current simplicity of the package it would probably be overkill.
