### PR TITLE
Only enable when in JSON/JavaScript syntax

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -4,7 +4,6 @@ import json
 import sys
 
 if sys.version_info > (2, 7, 0):
-    import json
     from collections import OrderedDict
 else:
     import simplejson as json
@@ -30,3 +29,9 @@ class PrettyjsonCommand(sublime_plugin.TextCommand):
                 self.view.replace(edit, selection, json.dumps(obj, indent=s.get("indent_size", 4), ensure_ascii=False, sort_keys=s.get("sort_keys", False), separators=(',', ': ')))
             except Exception, e:
                 sublime.status_message(str(e))
+
+    def is_enabled(self):
+        view = self.view
+        if view is None:
+            view = sublime.active_window().active_view()
+        return 'source.json' in view.scope_name(0) or 'source.javascript' in view.scope_name(0)


### PR DESCRIPTION
PrettyJSON should only be enabled when in the JSON or JavaScript syntax/context (ie: don't show command palette item when in PHP context).
