### PR TITLE
Add context to OSX key binding so that it only works in json scope

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -3,6 +3,7 @@
         "keys": [
             "super+ctrl+j"
         ], 
-        "command": "prettyjson"
+        "command": "prettyjson",
+        "context":  [{"key": "selector", "operator": "equal", "operand": "source.json"}]
     }
 ]


### PR DESCRIPTION
the key combination should only work in `source.json` scope. It minimizes the risk of key binding conflicts.
I recommend the same change for the other default key bindings.
