### PR TITLE
Sublime Text 3 library fix

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -4,8 +4,8 @@ import decimal
 
 try:
     # python 3 / Sublime Text 3
-    from . import json as simplejson
-    from .simplejson import OrderedDict
+    from . import json as json
+    from .json import OrderedDict
 except (ValueError):
     # python 2 / Sublime Text 2
     import simplejson as json


### PR DESCRIPTION
Current revision have this error on ST3: ImportError: No module named 'simplejson'

This pull request fixes the issue.
