### PR TITLE
defer `jq_exits` check until use

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -20,6 +20,7 @@ SUBLIME_MAJOR_VERSION = int(sublime.version()) / 1000
 
 jq_exits = False
 jq_version = None
+jq_init = False
 
 import subprocess
 
@@ -27,18 +28,27 @@ import subprocess
 if sys.platform != 'win32' and '/usr/local/bin' not in os.environ['PATH']:
     os.environ["PATH"] += os.pathsep + '/usr/local/bin'
 
-try:
-    # checking if ./jq tool is available so we can use it
-    s = subprocess.Popen(["jq", "--version"],
-                         stderr=subprocess.PIPE,
-                         stdout=subprocess.PIPE)
-    out, err = s.communicate()
-    jq_version = err.decode("utf-8").replace("jq version ", "").strip()
-    jq_exits = True
-except OSError:
-    os_exception = sys.exc_info()[1]
-    print(str(os_exception))
-    jq_exits = False
+""" defer jq presence check until the user tries to use it, include Package "Fix Mac Path" to resolve
+    all homebrew issues (https://github.com/int3h/SublimeFixMacPath) """
+def check_jq():
+    global jq_version
+    global jq_exits
+    global jq_init
+
+    if not jq_init:
+        jq_init = True
+        try:
+            # checking if ./jq tool is available so we can use it
+            s = subprocess.Popen(["jq", "--version"],
+                                 stderr=subprocess.PIPE,
+                                 stdout=subprocess.PIPE)
+            out, err = s.communicate()
+            jq_version = err.decode("utf-8").replace("jq version ", "").strip()
+            jq_exits = True
+        except OSError:
+            os_exception = sys.exc_info()[1]
+            print(str(os_exception))
+            jq_exits = False
 
 
 s = sublime.load_settings("Pretty JSON.sublime-settings")
@@ -169,6 +179,7 @@ class JqPrettyJson(sublime_plugin.WindowCommand):
     Allows work with ./jq
     """
     def run(self):
+        check_jq()
         if jq_exits:
             self.window.show_input_panel("Enter ./jq filter expression", ".",
                                          self.done, None, None)


### PR DESCRIPTION
mac os x launches sublime text with only system paths.  If you include the "Fix Mac Path" plugin in sublime text then the path will match what you would get in a standard bash shell.  The issue is that the plugins load concurrently and the path that sublime text has access to isn't updated until after the the PrettyJson plugin is loaded.

This PR defers the check until the user tries to use the ./jq functionality.