### PR TITLE
Fixed navigation in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install this sublime text 2/3 package via [Package Control](https://sublime.wbon
 
 ### or manually install
 
-- `cd <Packages directory>`   (for example on Mac it is `~/Library/Application Support/<Sublime Text Version>/Packages`)
+- `cd <Packages directory>`   (for example on Mac it is `~/Library/Application\ Support/Sublime\ Text\ 2/Packages`)
 - `git clone https://github.com/dzhibas/SublimePrettyJson.git`
 
 ## Usage


### PR DESCRIPTION
Just a small commit, I was unable to navigate to the folder on the command line on Unix (OS X).