### PR TITLE
Fix issue #62

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -290,7 +290,7 @@ class JqPrettyJson(sublime_plugin.WindowCommand):
                     out, err = p.communicate(unicode(raw_json).encode('utf-8'))
             else:
                 out, err = p.communicate(bytes(raw_json, "utf-8"))
-            output = out.decode("UTF-8").strip()
+            output = out.decode("UTF-8").replace(os.linesep, "\n").strip()
             if output:
                 view = self.window.new_file()
                 view.run_command("jq_pretty_json_out", {"jq_output": output})


### PR DESCRIPTION
I encountered issue #62, too.
My environmental is below.

* Sublime Text3 (Build 3126)
* This plugin (2016.09.01.14.51.10 or 3.0.7)
* Windows 10

The following is reasons of this PR.

`SubProcess.Popen.communicate()` returns result which include `CRLF` at Windows.
But on text editing area, Sublime text seems to show line endings as `LF` regardless of `default_line_ending`.

Perhaps `CRLF` seems to be translated to `LF` at loading file or saving file normally.
But `view.insert()` inserts `CRLF` into text editing area directly.

So I added `replace(os.linesep, "\n")` and fix this problem.

Best regards.