### PR TITLE
Sort matches before replacment on post process

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -90,6 +90,7 @@ class PrettyJsonBaseCommand:
         if post_process:
             # find all array matches
             matches = re.findall(r"\[([^\[\]]+?)\]", output_json)
+            matches.sort(key=len, reverse=True)
             join_separator = line_separator.ljust(2)
             for m in matches:
                 items = [a.strip() for a in m.split(line_separator.strip())]


### PR DESCRIPTION
The `post_process` behaves abnormally in some special cases.
It's because a match may be part of other matches.
Sorting matches from long to short can fix it.

Before
<img width="308" alt="screen shot 2017-02-18 at 7 09 18 pm" src="https://cloud.githubusercontent.com/assets/3337921/23093014/d0cf3cf0-f612-11e6-9ab9-bdeb9c7d940d.png">
After
<img width="304" alt="screen shot 2017-02-18 at 7 12 44 pm" src="https://cloud.githubusercontent.com/assets/3337921/23093016/d6154f42-f612-11e6-863a-3cb4202e716f.png">
Full JSON file: https://ideone.com/qWCzYJ