### PR TITLE
Added option to reindent prettified block to current indent level of selection

### DIFF
--- a/Pretty JSON.sublime-settings
+++ b/Pretty JSON.sublime-settings
@@ -8,5 +8,6 @@
     "keep_arrays_single_line": false,
     "max_arrays_line_length": 120,
     "pretty_on_save": false,
-    "validate_on_save": true
+    "validate_on_save": true,
+    "reindent_block": false
 }

--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -118,10 +118,27 @@ class PrettyJsonBaseCommand:
 
     def reindent(self, text, selection):
         current_line = self.view.line(selection.begin())
-        space_number = sublime.Region(current_line.begin(), selection.begin()).size()
-        indent_space = " " * space_number
+        text_before_sel = sublime.Region(
+            current_line.begin(), selection.begin())
+
+        reindent_mode = s.get('reindent_block', 'minimal')
+
+        if reindent_mode == 'start':
+            # Reindent to the column where the selection starts
+            space_number = text_before_sel.size()
+            indent_space = " " * space_number
+        else:
+            # Reindent to the number of spaces to the left of the
+            # line where the selection starts
+
+            # Extracts the spaces at the start of the line to use them
+            # as padding
+            indent_space = re.search(
+                '^\s*', self.view.substr(text_before_sel)).group(0)
+
         lines = text.split('\n')
 
+        # Pad every line except the first one
         i = 1
         while (i < len(lines)):
             lines[i] = indent_space + lines[i]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ http://stedolan.github.io/jq/
 **use_entire_file_if_no_selection** - true
 
 **indent** - 2
-`int used for how many spaces to use for indent, replace it with value "\t" and tabs will be used instead`
+
+    int used for how many spaces to use for indent, replace it with value "\t" and tabs will be used instead
 
 **sort_keys** - false
 
@@ -69,19 +70,53 @@ http://stedolan.github.io/jq/
 **line_separator** - ","
 
 **value_separator** - ": "
-`value separator in config, so if you need to get rid of extra space you can remove it with this param`
+
+    value separator in config, so if you need to get rid of extra space you can remove it with this param
 
 **keep_arrays_single_line** - false
-`if we need to re-structure arrays and make them single-line`
+
+    if we need to re-structure arrays and make them single-line
 
 **max_arrays_line_length** - 120 
-`if array for example '["a", "b", 123213, ....]' length will reach max it will be kept multi-line (for beauty)`
+
+    if array for example '["a", "b", 123213, ....]' length will reach max it will be kept multi-line (for beauty)
 
 **pretty_on_save** - false
-`do we need to automatically Pretty JSON on save`
+
+    do we need to automatically Pretty JSON on save
 
 **validate_on_save** - true
-`do we need validate JSON files on each save`
+
+    do we need validate JSON files on each save
+
+**reindent_block** - false
+
+    if we are formatting a selection, if we need to reindent the
+    resulting block to follow the flow of the source document
+    the posible values are 'minimal' and 'start'
+
+    using `minimal`, the resulting json lines are indented as much
+    spaces as the line where the selection starts. e.g
+
+        yaml_container:
+          yaml_key: { "json": "value" }
+
+    gets formatted as:
+
+        yaml_container:
+            yaml_key: {
+              "json": "value"
+            }
+
+    using `start`, the resulting json lines are indented a number
+    of spaces equal to the column number of the start of the selection
+
+    with `start` the previous example gets formatted as:
+
+        yaml_container:
+            yaml_key: {
+                        "json": "value"
+                      }
 
 ## Using tabs for indentation
 


### PR DESCRIPTION
When you have a JSON embedded in any other file (Markdown, YAML) and you want to format the json, you get something like this:

**Source**
~~~markdown
As is show in this json:

    {"key": "value"}
    
~~~

**Result**
~~~markdown
As is show in this json:

    {
  "key": "value"
}
    
~~~

Resulting in a broken markdown file.

What I would want as result is this:

**Desired result**
~~~markdown
As is show in this json:

    {
      "key": "value"
    }
    
~~~

This PR add the setting "reindent_block" to achieve this.