### PR TITLE
Fix an array parse error

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -96,7 +96,7 @@ class PrettyJsonBaseCommand:
                 replacement = join_separator.join(items)
                 # if line not gets too long, replace with single line
                 if len(replacement) <= s.get("max_arrays_line_length", 120):
-                    output_json = output_json.replace(m, replacement)
+                    output_json = output_json.replace(m, replacement, 1)
 
         return output_json
 


### PR DESCRIPTION
When parse an array with config `keep_arrays_single_line = true`, `output_json.replace(m, replacement)` will replace more than once if another array is a subset of current.
Example:
```{"a": [1],"b": [2,3,1]}```
should be parsed like: 
```
{
    "a": [1],
    "b": [2, 3, 1]
}
```
but actually got 
```
{
  "a": [1],
  "b": [
    2,
    3,1]
}
```