### PR TITLE
Add view object to self

### DIFF
--- a/PrettyJsonListeners.py
+++ b/PrettyJsonListeners.py
@@ -13,6 +13,7 @@ class PrettyJsonLintListener(sublime_plugin.EventListener, PrettyJsonBaseCommand
 
         as_json = s.get("as_json", ["JSON"])
         if any(syntax in view.settings().get("syntax") for syntax in as_json):
+            self.view = view
             self.clear_phantoms()
             json_content = view.substr(sublime.Region(0, view.size()))
             try:


### PR DESCRIPTION
Not sure why, but when the `self` object is passed to the `PrettyJsonLintListener::on_post_save` method, it does not have a `view` object as part of the data.

This just adds the view object that was passed in back to the `self` object.  

Seems to be like something else must be broken for this to happen, but all I really care about is having the save functionality working.