### PR TITLE
fix PrettyJsonLintListener

### DIFF
--- a/PrettyJsonListeners.py
+++ b/PrettyJsonListeners.py
@@ -6,15 +6,16 @@ from .PrettyJson import PrettyJsonBaseCommand
 s = sublime.load_settings("Pretty JSON.sublime-settings")
 
 
-class PrettyJsonLintListener(sublime_plugin.EventListener, PrettyJsonBaseCommand):
-    def on_post_save(self, view):
+class PrettyJsonLintListener(sublime_plugin.ViewEventListener, PrettyJsonBaseCommand):
+    def on_post_save(self):
         if not s.get("validate_on_save", True):
             return
 
         as_json = s.get("as_json", ["JSON"])
-        if any(syntax in view.settings().get("syntax") for syntax in as_json):
+        view_syntax = self.view.settings().get("syntax")
+        if any(syntax in view_syntax for syntax in as_json):
             self.clear_phantoms()
-            json_content = view.substr(sublime.Region(0, view.size()))
+            json_content = self.view.substr(sublime.Region(0, self.view.size()))
             try:
                 self.json_loads(json_content)
             except Exception as ex:

--- a/PrettyJsonListeners.py
+++ b/PrettyJsonListeners.py
@@ -28,5 +28,6 @@ class PrettyJsonAutoPrettyOnSaveListener(sublime_plugin.EventListener):
             return
 
         as_json = s.get("as_json", ["JSON"])
-        if any(syntax in view.settings().get("syntax") for syntax in as_json):
+        view_syntax = view.settings().get("syntax")
+        if any(syntax in view_syntax for syntax in as_json):
             view.run_command("pretty_json")


### PR DESCRIPTION
Fixes #180 

Replaces #181

This PR converts `PrettyJsonLintListener` into a `ViewEventListener`, so it contains `self.view` member, required by mixed in `PrettyJsonBaseCommand` class.