### PR TITLE
Fixes dzhibas/SublimePrettyJson#188

### DIFF
--- a/PrettyJson.py
+++ b/PrettyJson.py
@@ -508,6 +508,7 @@ class JqQueryPrettyJson(sublime_plugin.WindowCommand):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 stdin=subprocess.PIPE,
+                creationflags=subprocess.CREATE_NO_WINDOW,
             )
             QUERY_LEN = len(query)
             raw_json = self.get_content()


### PR DESCRIPTION
Spawning the window in the background caused significant latency, making the interactive jq function essentially useless on windows.